### PR TITLE
Update MISEnterpriseUpdater.m

### DIFF
--- a/MISEnterpriseUpdater-ObjC/MISEnterpriseUpdater.m
+++ b/MISEnterpriseUpdater-ObjC/MISEnterpriseUpdater.m
@@ -94,11 +94,7 @@ static NSString * const PKTEnterpriseUpdaterErrorInvalidPlistDescription = @"Inv
 
 + (NSString *)currentVersion
 {
-    NSString *currentVersion = [[NSBundle mainBundle] objectForInfoDictionaryKey:(NSString *)kCFBundleVersionKey];
-    if (currentVersion.length == 0) {
-        currentVersion = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
-    }
-    return currentVersion;
+    return [[NSBundle mainBundle]objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
 }
 
 @end


### PR DESCRIPTION
By default Xcode creates the manifest.plist with the app version, not the build number.